### PR TITLE
Stop using submodules

### DIFF
--- a/docs/src/reference/get_equality.md
+++ b/docs/src/reference/get_equality.md
@@ -1,12 +1,11 @@
-# GetEquality
+# Identifying equality constraints
 
 ```@meta
 CurrentModule = JuMPIn
 ```
 
 ```@docs
-GetEquality
-GetEquality.get_equality_constraints
-GetEquality.is_equality
-GetEquality.set_implies_equality
+get_equality_constraints
+is_equality
+set_implies_equality
 ```

--- a/docs/src/reference/identify_variables.md
+++ b/docs/src/reference/identify_variables.md
@@ -1,11 +1,10 @@
-# IdentifyVariables
+# Identifying variables in constraints
 
 ```@meta
 CurrentModule = JuMPIn
 ```
 
 ```@docs
-IdentifyVariables
-IdentifyVariables.identify_unique_variables
-IdentifyVariables._get_variable_terms
+identify_unique_variables
+_get_variable_terms
 ```

--- a/docs/src/reference/incidence_graph.md
+++ b/docs/src/reference/incidence_graph.md
@@ -1,10 +1,9 @@
-# IncidenceGraph
+# Incidence graph
 
 ```@meta
 CurrentModule = JuMPIn
 ```
 
 ```@docs
-IncidenceGraph
-IncidenceGraph.get_bipartite_incidence_graph
+get_bipartite_incidence_graph
 ```

--- a/docs/src/reference/interface.md
+++ b/docs/src/reference/interface.md
@@ -1,13 +1,12 @@
-# Interface
+# Algorithm interfaces
 
 ```@meta
 CurrentModule = JuMPIn
 ```
 
 ```@docs
-Interface
-Interface.IncidenceGraphInterface
-Interface.get_adjacent
-Interface.maximum_matching
-Interface.dulmage_mendelsohn
+IncidenceGraphInterface
+get_adjacent
+maximum_matching
+dulmage_mendelsohn
 ```

--- a/src/JuMPIn.jl
+++ b/src/JuMPIn.jl
@@ -18,25 +18,19 @@
 #  ___________________________________________________________________________
 
 module JuMPIn
-# TODO: Explicitly export functions?
-
-# Methods to identify variables
-include("identify_variables.jl") # IdentifyVariables
-identify_unique_variables = IdentifyVariables.identify_unique_variables
 
 # Methods to identify equality constraints
-include("get_equality.jl") # GetEquality
-get_equality_constraints = GetEquality.get_equality_constraints
+include("get_equality.jl")
+
+# Methods to identify variables
+include("identify_variables.jl")
 
 # Methods to get the incidence graph of constraints and variables
-include("incidence_graph.jl") # IncidenceGraph
-get_bipartite_incidence_graph = IncidenceGraph.get_bipartite_incidence_graph
+include("incidence_graph.jl")
 
 # Methods to apply graph algorithms to JuMP models
-include("interface.jl") # Interface
-IncidenceGraphInterface = Interface.IncidenceGraphInterface
-get_adjacent = Interface.get_adjacent
-maximum_matching = Interface.maximum_matching
-dulmage_mendelsohn = Interface.dulmage_mendelsohn
+include("maximum_matching.jl")
+include("dulmage_mendelsohn.jl")
+include("interface.jl")
 
 end

--- a/src/dulmage_mendelsohn.jl
+++ b/src/dulmage_mendelsohn.jl
@@ -17,11 +17,9 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-module DulmageMendelsohn
-
 import Graphs as gjl
-include("maximum_matching.jl") # MaximumMatching
-using .MaximumMatching: _is_valid_bipartition, maximum_matching
+
+import JuMPIn: maximum_matching, _is_valid_bipartition
 
 
 """
@@ -154,6 +152,4 @@ function dulmage_mendelsohn(graph::gjl.Graph, set1::Set)
         matched_with_reachable1,
         other2,
     ))
-end
-
 end

--- a/src/get_equality.jl
+++ b/src/get_equality.jl
@@ -22,28 +22,28 @@ Utility functions for identifying JuMP constraints that define equalities.
 
 """
 
-import JuMP as jmp
-import MathOptInterface as moi
+import JuMP
+import MathOptInterface as MOI
 
 function _get_set_of_constraint(
-    model::jmp.Model,
-    constraint::jmp.ConstraintRef,
-    index::moi.ConstraintIndex,
+    model::JuMP.Model,
+    constraint::JuMP.ConstraintRef,
+    index::MOI.ConstraintIndex,
 )
-    set = moi.get(model, moi.ConstraintSet(), constraint)
+    set = MOI.get(model, MOI.ConstraintSet(), constraint)
     return set
 end
 
 function _get_set_of_constraint(
-    model::jmp.Model,
-    constraint::jmp.ConstraintRef,
-    index::moi.Nonlinear.ConstraintIndex,
+    model::JuMP.Model,
+    constraint::JuMP.ConstraintRef,
+    index::MOI.Nonlinear.ConstraintIndex,
 )
     nl_con = model.nlp_model.constraints[index]
     return nl_con.set
 end
 
-function set_implies_equality(set::moi.EqualTo)::Bool
+function set_implies_equality(set::MOI.EqualTo)::Bool
     return true
 end
 
@@ -51,20 +51,20 @@ end
 # I.e. why is this interpreted as "set must be a subtype of Union(...)"
 # rather than "set must be an 'instance' of Union()".
 #function set_implies_equality(
-#    set::Union{moi.GreaterThan, moi.LessThan},
+#    set::Union{MOI.GreaterThan, MOI.LessThan},
 #    # Note that ^this works, but this doesn't
-#    # set::Type{<:Union{moi.GreaterThan, moi.LessThan}},
+#    # set::Type{<:Union{MOI.GreaterThan, MOI.LessThan}},
 #)::Bool
 #    return false
 #end
 
-function set_implies_equality(set::T)::Bool where T<:moi.AbstractVectorSet
-    throw(TypeError(set, moi.AbstractScalarSet, typeof(set)))
+function set_implies_equality(set::T)::Bool where T<:MOI.AbstractVectorSet
+    throw(TypeError(set, MOI.AbstractScalarSet, typeof(set)))
 end
 
 # NOTE: Have not implemented tolerance arg in any calling function yet.
 function set_implies_equality(
-    set::moi.Interval,
+    set::MOI.Interval,
     tolerance::Float64=Float64(0)
 )::Bool
     return abs(set.upper - set.lower) <= tolerance
@@ -75,9 +75,9 @@ end
 #
 # I intend this to catch anything that is a subtype of ConstraintSet.
 # Is the "subtype syntax" necessary?
-# It appears, e.g., moi.GreaterThan is not a subtype of moi.ConstraintSet.
+# It appears, e.g., MOI.GreaterThan is not a subtype of MOI.ConstraintSet.
 # This is non-intuitive for me...
-# So this won't catch arbitrary moi Sets...
+# So this won't catch arbitrary MOI Sets...
 # The right type to use is actually AbstractSet?
 # Nope. This doesn't catch GreatherThan/LessThan
 # ^ Wrong. Actually it does, but my syntax was wrong. I guess providing
@@ -103,7 +103,7 @@ types of constraints in [`is_equality`](@ref) and
 """
 function set_implies_equality(
     set::T
-)::Bool where T<:moi.AbstractSet
+)::Bool where T<:MOI.AbstractSet
     return false
 end
 
@@ -113,7 +113,7 @@ end
 Detect whether a constraint is an equality constraint.
 
 """
-function is_equality(constraint::jmp.ConstraintRef)::Bool
+function is_equality(constraint::JuMP.ConstraintRef)::Bool
     model = constraint.model
     index = constraint.index
     set = _get_set_of_constraint(model, constraint, index)
@@ -121,9 +121,9 @@ function is_equality(constraint::jmp.ConstraintRef)::Bool
 end
 
 function get_equality_constraints(
-    constraints::Vector{jmp.ConstraintRef}
-)::Vector{jmp.ConstraintRef}
-    eq_cons = Vector{jmp.ConstraintRef}()
+    constraints::Vector{JuMP.ConstraintRef}
+)::Vector{JuMP.ConstraintRef}
+    eq_cons = Vector{JuMP.ConstraintRef}()
     for con in constraints
         if is_equality(con)
             push!(eq_cons, con)
@@ -151,8 +151,8 @@ julia> display(eq_cons)
 ```
 
 """
-function get_equality_constraints(model::jmp.Model)::Vector{jmp.ConstraintRef}
-    constraints = jmp.all_constraints(
+function get_equality_constraints(model::JuMP.Model)::Vector{JuMP.ConstraintRef}
+    constraints = JuMP.all_constraints(
         model,
         include_variable_in_set_constraints=false,
     )

--- a/src/get_equality.jl
+++ b/src/get_equality.jl
@@ -25,7 +25,7 @@ Utility functions for identifying JuMP constraints that define equalities.
 import JuMP as jmp
 import MathOptInterface as moi
 
-function get_set_of_constraint(
+function _get_set_of_constraint(
     model::jmp.Model,
     constraint::jmp.ConstraintRef,
     index::moi.ConstraintIndex,
@@ -34,7 +34,7 @@ function get_set_of_constraint(
     return set
 end
 
-function get_set_of_constraint(
+function _get_set_of_constraint(
     model::jmp.Model,
     constraint::jmp.ConstraintRef,
     index::moi.Nonlinear.ConstraintIndex,
@@ -116,7 +116,7 @@ Detect whether a constraint is an equality constraint.
 function is_equality(constraint::jmp.ConstraintRef)::Bool
     model = constraint.model
     index = constraint.index
-    set = get_set_of_constraint(model, constraint, index)
+    set = _get_set_of_constraint(model, constraint, index)
     return set_implies_equality(set)
 end
 

--- a/src/get_equality.jl
+++ b/src/get_equality.jl
@@ -137,8 +137,6 @@ end
 
 Return a vector of equality constraints in the provided model.
 
-This function is also accessible via the `JuMPIn` module.
-
 # Example
 ```julia-repl
 julia> using JuMP

--- a/src/get_equality.jl
+++ b/src/get_equality.jl
@@ -21,7 +21,7 @@
 Utility functions for identifying JuMP constraints that define equalities.
 
 """
-module GetEquality
+
 import JuMP as jmp
 import MathOptInterface as moi
 
@@ -160,5 +160,3 @@ function get_equality_constraints(model::jmp.Model)::Vector{jmp.ConstraintRef}
     )
     return get_equality_constraints(constraints)
 end
-
-end # module get_equality

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -22,8 +22,8 @@ Utility functions for identifying variables that participate in constraints.
 
 """
 
-import JuMP as jmp
-import MathOptInterface as moi
+import JuMP
+import MathOptInterface as MOI
 
 import JuMPIn: get_equality_constraints
 
@@ -63,8 +63,8 @@ julia> display(vars)
 function identify_unique_variables(
     constraints::Vector,
     # FIXME: Couldn't get this working with Vector{ConstraintRef}...
-)::Vector{jmp.VariableRef}
-    variables = Vector{jmp.VariableRef}()
+)::Vector{JuMP.VariableRef}
+    variables = Vector{JuMP.VariableRef}()
     for con in constraints
         append!(variables, identify_unique_variables(con))
     end
@@ -81,14 +81,14 @@ Each variable appears at most one time in the returned vector.
 
 """
 function identify_unique_variables(
-    model::jmp.Model; include_inequality::Bool=false,
-)::Vector{jmp.VariableRef}
+    model::JuMP.Model; include_inequality::Bool=false,
+)::Vector{JuMP.VariableRef}
     if include_inequality
         # Note that this may include some constraints which are not compatible
         # with downstream function calls (e.g. constraints where the function
         # and terms are vectors). We will allow downstream errors to be raised
         # rather than silently ignoring these constraints.
-        constraints = jmp.all_constraints(
+        constraints = JuMP.all_constraints(
             model,
             # TODO: Should this be an optional argument to this function?
             include_variable_in_set_constraints=false,
@@ -109,8 +109,8 @@ Each variable appears at most one time in the returned vector.
 
 """
 function identify_unique_variables(
-    constraint::jmp.ConstraintRef,
-)::Vector{jmp.VariableRef}
+    constraint::JuMP.ConstraintRef,
+)::Vector{JuMP.VariableRef}
     return identify_unique_variables(constraint, constraint.index)
 end
 
@@ -129,13 +129,13 @@ constraint or a nonlinear constraint.
 
 """
 function identify_unique_variables(
-    constraint::jmp.ConstraintRef,
-    index::moi.ConstraintIndex,
-)::Vector{jmp.VariableRef}
+    constraint::JuMP.ConstraintRef,
+    index::MOI.ConstraintIndex,
+)::Vector{JuMP.VariableRef}
     model = constraint.model
-    fcn = moi.get(model, moi.ConstraintFunction(), constraint)
+    fcn = MOI.get(model, MOI.ConstraintFunction(), constraint)
     varidxs = identify_unique_variables(fcn)
-    varrefs = [jmp.VariableRef(model, idx) for idx in varidxs]
+    varrefs = [JuMP.VariableRef(model, idx) for idx in varidxs]
     return varrefs
 end
 
@@ -154,9 +154,9 @@ constraint or a nonlinear constraint.
 
 """
 function identify_unique_variables(
-    constraint::jmp.ConstraintRef,
-    index::moi.Nonlinear.ConstraintIndex,
-)::Vector{jmp.VariableRef}
+    constraint::JuMP.ConstraintRef,
+    index::MOI.Nonlinear.ConstraintIndex,
+)::Vector{JuMP.VariableRef}
     model = constraint.model
     nlmod = model.nlp_model
     nlcons = nlmod.constraints
@@ -167,11 +167,11 @@ function identify_unique_variables(
     # This could be its own function, but I inlined it here to allow a more
     # useful error message if we ever encounter NODE_VARIABLE.
     # Will be moved when/if the need arises.
-    variables = Vector{moi.VariableIndex}()
+    variables = Vector{MOI.VariableIndex}()
     for node in expr.nodes
-        if node.type == moi.Nonlinear.NODE_MOI_VARIABLE
-            push!(variables, moi.VariableIndex(node.index))
-        elseif node.type == moi.Nonlinear.NODE_VARIABLE
+        if node.type == MOI.Nonlinear.NODE_MOI_VARIABLE
+            push!(variables, MOI.VariableIndex(node.index))
+        elseif node.type == MOI.Nonlinear.NODE_VARIABLE
             # I do not know under what situation this could occur, but
             # am throwing this error to be defensive.
             throw(DomainError(
@@ -185,7 +185,7 @@ function identify_unique_variables(
     end
 
     # Return VariableRefs
-    refs = [jmp.VariableRef(model, idx) for idx in variables]
+    refs = [JuMP.VariableRef(model, idx) for idx in variables]
     return _filter_duplicates(refs)
 end
 
@@ -204,9 +204,9 @@ function should be implemented.
 
 """
 function identify_unique_variables(
-    fcn::Union{moi.ScalarQuadraticFunction, moi.ScalarAffineFunction},
-)::Vector{moi.VariableIndex}
-    variables = Vector{moi.VariableIndex}()
+    fcn::Union{MOI.ScalarQuadraticFunction, MOI.ScalarAffineFunction},
+)::Vector{MOI.VariableIndex}
+    variables = Vector{MOI.VariableIndex}()
     for terms in _get_variable_terms(fcn)
         for term in terms
             for var in identify_unique_variables(term)
@@ -219,10 +219,10 @@ end
 
 function identify_unique_variables(
     fcn::T
-)::Vector{moi.VariableIndex} where {T<:moi.AbstractVectorFunction}
+)::Vector{MOI.VariableIndex} where {T<:MOI.AbstractVectorFunction}
     throw(TypeError(
         fcn,
-        Union{moi.ScalarQuadraticFunction, moi.ScalarAffineFunction},
+        Union{MOI.ScalarQuadraticFunction, MOI.ScalarAffineFunction},
         typeof(fcn),
     ))
 end
@@ -238,11 +238,11 @@ Currently implemented only for `ScalarQuadraticFunction` and
 `ScalarAffineFunction`.
 
 """
-function _get_variable_terms(fcn::moi.ScalarQuadraticFunction)
+function _get_variable_terms(fcn::MOI.ScalarQuadraticFunction)
     return (fcn.quadratic_terms, fcn.affine_terms)
 end
 
-function _get_variable_terms(fcn::moi.ScalarAffineFunction)
+function _get_variable_terms(fcn::MOI.ScalarAffineFunction)
     return (fcn.terms,)
 end
 
@@ -260,14 +260,14 @@ Currently implemented only for `ScalarAffineTerm` and `ScalarQuadraticTerm`.
 
 """
 function identify_unique_variables(
-    term::moi.ScalarAffineTerm,
-)::Vector{moi.VariableIndex}
+    term::MOI.ScalarAffineTerm,
+)::Vector{MOI.VariableIndex}
     return [term.variable]
 end
 
 function identify_unique_variables(
-    term::moi.ScalarQuadraticTerm,
-)::Vector{moi.VariableIndex}
+    term::MOI.ScalarQuadraticTerm,
+)::Vector{MOI.VariableIndex}
     # Note that this compares indices only. If somehow these indices refer to
     # different models, this could be incorrect.
     if term.variable_1 === term.variable_2
@@ -285,12 +285,12 @@ Return a vector of variables of indices that does not contain duplicates.
 
 """
 function _filter_duplicates(
-    indices::Vector{moi.VariableIndex},
-)::Vector{moi.VariableIndex}
+    indices::Vector{MOI.VariableIndex},
+)::Vector{MOI.VariableIndex}
     # Note that by hashing only the variable index, we implicitly assume that
     # all variables come from the same model. I believe this is safe.
-    seen = Set{moi.VariableIndex}()
-    filtered = Vector{moi.VariableIndex}()
+    seen = Set{MOI.VariableIndex}()
+    filtered = Vector{MOI.VariableIndex}()
     for idx in indices
         if !(idx in seen)
             push!(seen, idx)
@@ -302,12 +302,12 @@ end
 
 
 function _filter_duplicates(
-    variables::Vector{jmp.VariableRef},
-)::Vector{jmp.VariableRef}
+    variables::Vector{JuMP.VariableRef},
+)::Vector{JuMP.VariableRef}
     # What happens when VariableRef gets hashed? I.e. how is the
     # hash of the model computed?
-    seen = Set{jmp.VariableRef}()
-    filtered = Vector{jmp.VariableRef}()
+    seen = Set{JuMP.VariableRef}()
+    filtered = Vector{JuMP.VariableRef}()
     for var in variables
         if !(var in seen)
             push!(seen, var)

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -21,12 +21,11 @@
 Utility functions for identifying variables that participate in constraints.
 
 """
-module IdentifyVariables
+
 import JuMP as jmp
 import MathOptInterface as moi
 
-include("get_equality.jl")
-using .GetEquality: get_equality_constraints
+import JuMPIn: get_equality_constraints
 
 
 # TODO: This file implements functions that filter duplicates from the
@@ -318,6 +317,4 @@ function _filter_duplicates(
         end
     end
     return filtered
-end
-
 end

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -44,8 +44,6 @@ If we receive a vector, we just assume it is a vector of constraints.
 This is because I couldn't get an argument of type `Vector{ConstraintRef}`
 to work...
 
-Note that this function is also accessible via the JuMPIn module.
-
 # Example
 ```julia-repl
 julia> using JuMP

--- a/src/incidence_graph.jl
+++ b/src/incidence_graph.jl
@@ -48,8 +48,6 @@ This function returns a tuple `(graph, con_node_map, var_node_map)`
 The constraints in the graph are all the (by default, equality) constraints in
 the model, and the variables are those that participate in these constraints.
 
-This function can also be accessed via the `JuMPIn` module.
-
 # Example
 ```julia-repl
 julia> using JuMP

--- a/src/incidence_graph.jl
+++ b/src/incidence_graph.jl
@@ -23,8 +23,7 @@ variables.
 
 """
 
-import JuMP as jmp
-import MathOptInterface as moi
+import JuMP
 
 import JuMPIn: get_equality_constraints, identify_unique_variables
 
@@ -84,11 +83,11 @@ regardless of which variables participate in the constraints.
 
 """
 function get_bipartite_incidence_graph(
-    model::jmp.Model;
+    model::JuMP.Model;
     include_inequality::Bool = false,
 )
     if include_inequality
-        constraints = jmp.all_constraints(
+        constraints = JuMP.all_constraints(
             model,
             # TODO: Should this be an optional argument to this function?
             include_variable_in_set_constraints=false,
@@ -103,7 +102,7 @@ function get_bipartite_incidence_graph(
     return get_bipartite_incidence_graph(constraints)
 end
 
-function get_bipartite_incidence_graph(constraints::Vector{jmp.ConstraintRef})
+function get_bipartite_incidence_graph(constraints::Vector{JuMP.ConstraintRef})
     variables = identify_unique_variables(constraints)
     # We could build up a variable-index map dynamically to get the incidence
     # in a single loop over the constraints, but this is easier to implement.
@@ -111,8 +110,8 @@ function get_bipartite_incidence_graph(constraints::Vector{jmp.ConstraintRef})
 end
 
 function get_bipartite_incidence_graph(
-    constraints::Vector{jmp.ConstraintRef},
-    variables::Vector{jmp.VariableRef},
+    constraints::Vector{JuMP.ConstraintRef},
+    variables::Vector{JuMP.VariableRef},
 )
     ncon = length(constraints)
     nvar = length(variables)
@@ -121,8 +120,8 @@ function get_bipartite_incidence_graph(
     con_nodes = Vector(1:ncon)
     var_nodes = Vector(ncon+1:ncon+nvar)
 
-    con_node_map = Dict{jmp.ConstraintRef, Int64}(zip(constraints, con_nodes))
-    var_node_map = Dict{jmp.VariableRef, Int64}(zip(variables, var_nodes))
+    con_node_map = Dict{JuMP.ConstraintRef, Int64}(zip(constraints, con_nodes))
+    var_node_map = Dict{JuMP.VariableRef, Int64}(zip(variables, var_nodes))
 
     # This could be violated if a variable or constraint appears multiple times.
     # TODO: Fail more gracefully if this happens.

--- a/src/incidence_graph.jl
+++ b/src/incidence_graph.jl
@@ -22,16 +22,11 @@ Utility functions for getting the incidence graph of JuMP constraints and
 variables.
 
 """
-module IncidenceGraph
 
 import JuMP as jmp
 import MathOptInterface as moi
 
-include("get_equality.jl")
-using .GetEquality: get_equality_constraints
-
-include("identify_variables.jl")
-using .IdentifyVariables: identify_unique_variables
+import JuMPIn: get_equality_constraints, identify_unique_variables
 
 """
     get_bipartite_incidence_graph(model, include_inequality = false)
@@ -152,5 +147,3 @@ function get_bipartite_incidence_graph(
     # have ordered vectors of constraints and variables.
     return graph, con_node_map, var_node_map
 end
-
-end # module IncidenceGraph

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -20,9 +20,6 @@
 """
 A JuMP interface to the algorithms implemented by JuMPIn
 
-All public methods in this module (those documented below) are also accessible
-via the `JuMPIn` module.
-
 """
 
 import JuMP as jmp

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -22,7 +22,7 @@ A JuMP interface to the algorithms implemented by JuMPIn
 
 """
 
-import JuMP as jmp
+import JuMP
 
 import JuMPIn: get_bipartite_incidence_graph, maximum_matching
 
@@ -111,7 +111,7 @@ IncidenceGraphInterface(
 
 
 IncidenceGraphInterface(
-    m::jmp.Model;
+    m::JuMP.Model;
     include_inequality::Bool = false,
 ) = IncidenceGraphInterface(
     get_bipartite_incidence_graph(m, include_inequality = include_inequality)
@@ -119,8 +119,8 @@ IncidenceGraphInterface(
 
 
 IncidenceGraphInterface(
-    constraints::Vector{jmp.ConstraintRef},
-    variables::Vector{jmp.VariableRef},
+    constraints::Vector{JuMP.ConstraintRef},
+    variables::Vector{JuMP.VariableRef},
 ) = IncidenceGraphInterface(
     get_bipartite_incidence_graph(constraints, variables)
 )
@@ -137,7 +137,7 @@ Return the variables adjacent to a constraint in an incidence graph.
 """
 function get_adjacent(
     igraph::IncidenceGraphInterface,
-    constraint::jmp.ConstraintRef,
+    constraint::JuMP.ConstraintRef,
 )
     con_node = igraph._con_node_map[constraint]
     var_nodes = gjl.neighbors(igraph._graph, con_node)
@@ -173,7 +173,7 @@ julia> display(adj_cons)
 """
 function get_adjacent(
     igraph::IncidenceGraphInterface,
-    variable::jmp.VariableRef,
+    variable::JuMP.VariableRef,
 )
     var_node = igraph._var_node_map[variable]
     con_nodes = gjl.neighbors(igraph._graph, var_node)
@@ -208,7 +208,7 @@ Dict{ConstraintRef{Model, C, ScalarShape} where C, VariableRef} with 2 entries:
 """
 function maximum_matching(
     igraph::IncidenceGraphInterface
-)::Dict{jmp.ConstraintRef, jmp.VariableRef}
+)::Dict{JuMP.ConstraintRef, JuMP.VariableRef}
     ncon = length(igraph._con_node_map)
     nodes = igraph._nodes
     con_node_set = Set(1:ncon) # Relying on graph convention here.
@@ -220,9 +220,9 @@ end
 
 
 function maximum_matching(
-    constraints::Vector{jmp.ConstraintRef},
-    variables::Vector{jmp.VariableRef},
-)::Dict{jmp.ConstraintRef, jmp.VariableRef}
+    constraints::Vector{JuMP.ConstraintRef},
+    variables::Vector{JuMP.VariableRef},
+)::Dict{JuMP.ConstraintRef, JuMP.VariableRef}
     igraph = IncidenceGraphInterface(constraints, variables)
     return maximum_matching(igraph)
 end
@@ -332,8 +332,8 @@ end
 
 
 function dulmage_mendelsohn(
-    constraints::Vector{jmp.ConstraintRef},
-    variables::Vector{jmp.VariableRef},
+    constraints::Vector{JuMP.ConstraintRef},
+    variables::Vector{JuMP.VariableRef},
 )
     igraph = IncidenceGraphInterface(constraints, variables)
     return dulmage_mendelsohn(igraph)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -24,17 +24,10 @@ All public methods in this module (those documented below) are also accessible
 via the `JuMPIn` module.
 
 """
-module Interface
 
 import JuMP as jmp
 
-include("incidence_graph.jl")
-using .IncidenceGraph: get_bipartite_incidence_graph
-
-include("maximum_matching.jl")
-import .MaximumMatching: maximum_matching
-include("dulmage_mendelsohn.jl")
-import .DulmageMendelsohn: dulmage_mendelsohn
+import JuMPIn: get_bipartite_incidence_graph, maximum_matching
 
 import Graphs as gjl
 import BipartiteMatching as bpm
@@ -348,6 +341,3 @@ function dulmage_mendelsohn(
     igraph = IncidenceGraphInterface(constraints, variables)
     return dulmage_mendelsohn(igraph)
 end
-
-
-end # module Interface

--- a/src/maximum_matching.jl
+++ b/src/maximum_matching.jl
@@ -17,8 +17,6 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-module MaximumMatching
-
 import Graphs as gjl
 import BipartiteMatching as bpm
 
@@ -62,6 +60,4 @@ function maximum_matching(graph::gjl.Graph, set1::Set)
     # Translate row/column coordinates back into nodes of the graph
     graph_matching = Dict(nodes1[r] => nodes2[c] for (r, c) in matching)
     return graph_matching
-end
-
 end


### PR DESCRIPTION
Pros of submodules:
- More explicit definition of what lives at the "top level" of a package
- Only have to remember one thing that gets added by an `include`
- Less chance of namespace collision

Cons of submodules
- Same functions can "live" in multiple places. E.g. `JuMPIn.identify_unique_variables` and `JuMPIn.IdentifyVariables.identify_unique_variables`
- Weird situations where `JuMPIn.IncidenceGraph.IdentifyVariables !== JuMPIn.IdentifyVariables`
- Julia standard seems to be to not use them
- Flat is better than nested