### PR TITLE
Allow subtypes of `ConstraintRef` in methods that accept vectors of constraints

### DIFF
--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -61,8 +61,7 @@ julia> display(vars)
 
 """
 function identify_unique_variables(
-    constraints::Vector,
-    # FIXME: Couldn't get this working with Vector{ConstraintRef}...
+    constraints::Vector{<:JuMP.ConstraintRef},
 )::Vector{JuMP.VariableRef}
     variables = Vector{JuMP.VariableRef}()
     for con in constraints

--- a/src/incidence_graph.jl
+++ b/src/incidence_graph.jl
@@ -27,6 +27,15 @@ import JuMP
 
 import JuMPIn: get_equality_constraints, identify_unique_variables
 
+const GraphDataTuple = Tuple{
+    # (A, B, E) describing the bipartite graph
+    Tuple{Vector{Int}, Vector{Int}, Vector{Tuple{Int, Int}}},
+    # Map from constraints to nodes (in A)
+    Dict{JuMP.ConstraintRef, Int},
+    # Map from variables to nodes (in B)
+    Dict{JuMP.VariableRef, Int},
+}
+
 """
     get_bipartite_incidence_graph(model, include_inequality = false)
 
@@ -85,7 +94,7 @@ regardless of which variables participate in the constraints.
 function get_bipartite_incidence_graph(
     model::JuMP.Model;
     include_inequality::Bool = false,
-)
+)::GraphDataTuple
     if include_inequality
         # Note that this may generate some constraints that are incompatible
         # with downstream function calls (e.g. constraints involving vector
@@ -109,7 +118,9 @@ function get_bipartite_incidence_graph(
     return get_bipartite_incidence_graph(constraints)
 end
 
-function get_bipartite_incidence_graph(constraints::Vector{JuMP.ConstraintRef})
+function get_bipartite_incidence_graph(
+    constraints::Vector{<:JuMP.ConstraintRef}
+)::GraphDataTuple
     variables = identify_unique_variables(constraints)
     # We could build up a variable-index map dynamically to get the incidence
     # in a single loop over the constraints, but this is easier to implement.
@@ -117,9 +128,9 @@ function get_bipartite_incidence_graph(constraints::Vector{JuMP.ConstraintRef})
 end
 
 function get_bipartite_incidence_graph(
-    constraints::Vector{JuMP.ConstraintRef},
+    constraints::Vector{<:JuMP.ConstraintRef},
     variables::Vector{JuMP.VariableRef},
-)
+)::GraphDataTuple
     ncon = length(constraints)
     nvar = length(variables)
     # Note the convention we apply: Constraints take the first 1:ncon

--- a/test/identify_variables.jl
+++ b/test/identify_variables.jl
@@ -199,6 +199,17 @@ function test_inequality_with_bounds()
     @test Set(variables) == pred_var_set
 end
 
+function test_two_constraints_same_type()
+    m = jmp.Model()
+    @jmp.variable(m, x[1:3])
+    @jmp.constraint(m, eq1, x[1] + x[2] == 2)
+    @jmp.constraint(m, eq2, x[2] + 2*x[3] == 3)
+    cons = [eq1, eq2]
+    vars = identify_unique_variables(cons)
+    pred_var_set = Set([x[1], x[2], x[3]])
+    @test Set(vars) == pred_var_set
+end
+
 function runtests()
     test_linear()
     test_quadratic()
@@ -213,6 +224,7 @@ function runtests()
     test_function_with_variable_squared()
     test_fixing_constraint()
     test_inequality_with_bounds()
+    test_two_constraints_same_type()
     return
 end
 


### PR DESCRIPTION
## Fixes #9
Had problems when a vector of subtypes of ConstraintRef was provided, which is what we get by constructing these vectors without specifying the types.

Piggybacking off this to add return types to `get_bipartite_incidence_graph` and `dulmage_mendelsohn`.