### PR TITLE
More conventional importing of dependencies

### DIFF
--- a/src/dulmage_mendelsohn.jl
+++ b/src/dulmage_mendelsohn.jl
@@ -17,7 +17,7 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-import Graphs as gjl
+import Graphs
 
 import JuMPIn: maximum_matching, _is_valid_bipartition
 
@@ -27,12 +27,12 @@ In this function, matching must contain a key for every matched node.
 I.e., Set(keys(matching)) == Set(values(matching))
 """
 function _get_projected_digraph(
-    graph::gjl.Graph, nodes::Vector, matching::Dict
+    graph::Graphs.Graph, nodes::Vector, matching::Dict
 )
     # Note that we are constructing a graph in a projected space, and must
     # be aware of whether coordinates are in original or projected spaces.
     orig_proj_map = Dict(n => i for (i, n) in enumerate(nodes))
-    n_nodes = gjl.nv(graph)
+    n_nodes = Graphs.nv(graph)
     n_nodes_proj = length(nodes)
     matched_nodes = keys(matching)
     node_set = Set(nodes) # Set of nodes in the original space
@@ -41,7 +41,7 @@ function _get_projected_digraph(
         orig_node = nodes[proj_node]
         if orig_node in matched_nodes
             # In-edges from all (other) neighbors of matched node
-            for nbr in gjl.neighbors(graph, matching[orig_node])
+            for nbr in Graphs.neighbors(graph, matching[orig_node])
                 if nbr != orig_node
                     nbr_proj = orig_proj_map[nbr]
                     push!(edge_set, (nbr_proj, proj_node))
@@ -50,29 +50,29 @@ function _get_projected_digraph(
         end
         # TODO: Out edges?
     end
-    digraph = gjl.DiGraph(n_nodes_proj)
+    digraph = Graphs.DiGraph(n_nodes_proj)
     for (n1, n2) in edge_set
-        gjl.add_edge!(digraph, n1, n2)
+        Graphs.add_edge!(digraph, n1, n2)
     end
     return digraph, orig_proj_map
 end
 
 
-function _get_reachable_from(digraph::gjl.DiGraph, nodes::Vector)
-    n_nodes = gjl.nv(digraph)
+function _get_reachable_from(digraph::Graphs.DiGraph, nodes::Vector)
+    n_nodes = Graphs.nv(digraph)
     source_set = Set(nodes)
-    gjl.add_vertex!(digraph)
+    Graphs.add_vertex!(digraph)
     # Note that root needs to be in this scope so it can be accessed in
     # finally block
     root = n_nodes + 1
     bfs_parents = Vector{Int64}()
     try
         for node in nodes
-            gjl.add_edge!(digraph, root, node)
+            Graphs.add_edge!(digraph, root, node)
         end
-        bfs_parents = gjl.bfs_parents(digraph, root)
+        bfs_parents = Graphs.bfs_parents(digraph, root)
     finally
-        gjl.rem_vertex!(digraph, root)
+        Graphs.rem_vertex!(digraph, root)
     end
     reachable = [
         node for (node, par) in enumerate(bfs_parents)
@@ -82,11 +82,11 @@ function _get_reachable_from(digraph::gjl.DiGraph, nodes::Vector)
 end
 
 
-function dulmage_mendelsohn(graph::gjl.Graph, set1::Set)
+function dulmage_mendelsohn(graph::Graphs.Graph, set1::Set)
     if !_is_valid_bipartition(graph, set1)
         throw(Exception)
     end
-    n_nodes = gjl.nv(graph)
+    n_nodes = Graphs.nv(graph)
     set2 = setdiff(Set(1:n_nodes), set1)
 
     # Compute maximum matching between bipartite sets

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -26,9 +26,7 @@ import JuMP
 
 import JuMPIn: get_bipartite_incidence_graph, maximum_matching, GraphDataTuple
 
-import Graphs as gjl
-import BipartiteMatching as bpm
-
+import Graphs
 
 """
 Utility function to convert a tuple of nodes and edges into a
@@ -39,16 +37,15 @@ function _tuple_to_graphs_jl(bip_graph)
     # Assumption here is that A and B are disjoint. And also form
     # a partition of 1:nv.
     nv = length(A) + length(B)
-    graph = gjl.Graph(gjl.Edge.(E))
+    graph = Graphs.Graph(Graphs.Edge.(E))
     # If E does not cover all vertices, some vertices may not appear in the
     # graph. Add these missing vertices.
-    n_missing = nv - gjl.nv(graph)
-    gjl.add_vertices!(graph, n_missing)
+    n_missing = nv - Graphs.nv(graph)
+    Graphs.add_vertices!(graph, n_missing)
     # Note that by constructing this graph, we have lost our particular
     # bipartition.
     return graph
 end
-
 
 function _maps_to_nodes(con_map, var_map)
     n_nodes = length(con_map) + length(var_map)
@@ -64,7 +61,6 @@ function _maps_to_nodes(con_map, var_map)
     end
     return nodes
 end
-
 
 """
     IncidenceGraphInterface(model; include_inequality = false)
@@ -99,7 +95,6 @@ struct IncidenceGraphInterface
     _nodes
 end
 
-
 IncidenceGraphInterface(
     args::GraphDataTuple
 ) = IncidenceGraphInterface(
@@ -109,7 +104,6 @@ IncidenceGraphInterface(
     _maps_to_nodes(args[2], args[3]),
 )
 
-
 IncidenceGraphInterface(
     m::JuMP.Model;
     include_inequality::Bool = false,
@@ -117,14 +111,12 @@ IncidenceGraphInterface(
     get_bipartite_incidence_graph(m, include_inequality = include_inequality)
 )
 
-
 IncidenceGraphInterface(
     constraints::Vector{<:JuMP.ConstraintRef},
     variables::Vector{JuMP.VariableRef},
 ) = IncidenceGraphInterface(
     get_bipartite_incidence_graph(constraints, variables)
 )
-
 
 """
     get_adjacent(
@@ -140,11 +132,10 @@ function get_adjacent(
     constraint::JuMP.ConstraintRef,
 )::Vector{JuMP.VariableRef}
     con_node = igraph._con_node_map[constraint]
-    var_nodes = gjl.neighbors(igraph._graph, con_node)
+    var_nodes = Graphs.neighbors(igraph._graph, con_node)
     variables = [igraph._nodes[n] for n in var_nodes]
     return variables
 end
-
 
 """
     get_adjacent(
@@ -176,11 +167,10 @@ function get_adjacent(
     variable::JuMP.VariableRef,
 )::Vector{JuMP.ConstraintRef}
     var_node = igraph._var_node_map[variable]
-    con_nodes = gjl.neighbors(igraph._graph, var_node)
+    con_nodes = Graphs.neighbors(igraph._graph, var_node)
     constraints = [igraph._nodes[n] for n in con_nodes]
     return constraints
 end
-
 
 """
     maximum_matching(igraph::IncidenceGraphInterface)::Dict
@@ -350,7 +340,6 @@ function dulmage_mendelsohn(
     )
     return con_dmp, var_dmp
 end
-
 
 function dulmage_mendelsohn(
     constraints::Vector{<:JuMP.ConstraintRef},

--- a/src/maximum_matching.jl
+++ b/src/maximum_matching.jl
@@ -17,27 +17,27 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-import Graphs as gjl
-import BipartiteMatching as bpm
+import Graphs
+import BipartiteMatching as BM
 
 
 """
 TODO: This should probably be promoted to Graphs.jl
 """
-function _is_valid_bipartition(graph::gjl.Graph, set1::Set)
-    n_nodes = gjl.nv(graph)
+function _is_valid_bipartition(graph::Graphs.Graph, set1::Set)
+    n_nodes = Graphs.nv(graph)
     all_nodes = Set(1:n_nodes)
     if !issubset(set1, all_nodes)
         throw(Exception)
     end
     set2 = setdiff(all_nodes, set1)
     for node in set1
-        if !issubset(gjl.neighbors(graph, node), set2)
+        if !issubset(Graphs.neighbors(graph, node), set2)
             return false
         end
     end
     for node in set2
-        if !issubset(gjl.neighbors(graph, node), set1)
+        if !issubset(Graphs.neighbors(graph, node), set1)
             return false
         end
     end
@@ -45,18 +45,18 @@ function _is_valid_bipartition(graph::gjl.Graph, set1::Set)
 end
 
 
-function maximum_matching(graph::gjl.Graph, set1::Set)
+function maximum_matching(graph::Graphs.Graph, set1::Set)
     if !_is_valid_bipartition(graph, set1)
         throw(Exception)
     end
-    n_nodes = gjl.nv(graph)
+    n_nodes = Graphs.nv(graph)
     card1 = length(set1)
     nodes1 = sort([node for node in set1])
     set2 = setdiff(Set(1:n_nodes), set1)
     nodes2 = sort([node for node in set2])
-    edge_set = Set((n1, n2) for n1 in nodes1 for n2 in gjl.neighbors(graph, n1))
+    edge_set = Set((n1, n2) for n1 in nodes1 for n2 in Graphs.neighbors(graph, n1))
     amat = BitArray{2}((r, c) in edge_set for r in nodes1, c in nodes2)
-    matching, _ = bpm.findmaxcardinalitybipartitematching(amat)
+    matching, _ = BM.findmaxcardinalitybipartitematching(amat)
     # Translate row/column coordinates back into nodes of the graph
     graph_matching = Dict(nodes1[r] => nodes2[c] for (r, c) in matching)
     return graph_matching

--- a/test/get_equality.jl
+++ b/test/get_equality.jl
@@ -17,17 +17,15 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-module TestGetEquality
 import JuMP
-import MathOptInterface as moi
-using Test: @test, @test_throws
+import MathOptInterface as MOI
+using Test: @test, @test_throws, @testset
 using JuMPIn: get_equality_constraints
 
-include("models.jl") # Models
+include("models.jl") # make_degenerate_flow_model
 
 function get_flow_model_with_inequalities()
-    m = Models.make_degenerate_flow_model()
-    # TODO: Some assertions with the @assert macro
+    m = make_degenerate_flow_model()
     @JuMP.constraint(m, ineq1, m[:x][1] >= 0)
     @JuMP.constraint(m, ineq2, m[:x][1]^2 + m[:x][2]^2 <= 0.5)
     @JuMP.NLconstraint(m, ineq3, sqrt(m[:x][3]) >= 0.1)
@@ -44,7 +42,7 @@ end
 function test_with_vector_constraint()
     m = JuMP.Model()
     @JuMP.variable(m, var[1:2])
-    @JuMP.constraint(m, con, var in moi.Nonnegatives(2))
+    @JuMP.constraint(m, con, var in MOI.Nonnegatives(2))
     @test_throws(TypeError, eq_cons = get_equality_constraints(m))
 end
 
@@ -59,14 +57,8 @@ function test_with_fixed_variables()
     @test length(eq_cons) == 1
 end
 
-function runtests()
+@testset "get-equality" begin
     test_flow_model_with_inequalities()
     test_with_vector_constraint()
     test_with_fixed_variables()
-end
-
-end # module TestGetEquality
-
-if abspath(PROGRAM_FILE) == @__FILE__
-    TestGetEquality.runtests()
 end

--- a/test/incidence_graph.jl
+++ b/test/incidence_graph.jl
@@ -17,15 +17,12 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-module TestIncidenceGraph
-
-import JuMP as jmp
-import MathOptInterface as moi
-using Test: @test, @test_throws
+import JuMP
+import MathOptInterface as MOI
+using Test: @test, @test_throws, @testset
 using JuMPIn: get_bipartite_incidence_graph
 
-include("models.jl") # Models
-using .Models: make_degenerate_flow_model
+include("models.jl") # make_degenerate_flow_model
 
 function test_get_incidence_graph()
     m = make_degenerate_flow_model()
@@ -84,8 +81,8 @@ end
 
 function test_get_incidence_graph_badconstraint()
     m = make_degenerate_flow_model()
-    @jmp.variable(m, var[1:2])
-    @jmp.constraint(m, vectorcon, var in moi.Nonnegatives(2))
+    @JuMP.variable(m, var[1:2])
+    @JuMP.constraint(m, vectorcon, var in MOI.Nonnegatives(2))
     @test_throws(
         TypeError,
         get_bipartite_incidence_graph(m, include_inequality=true),
@@ -94,9 +91,9 @@ function test_get_incidence_graph_badconstraint()
 end
 
 function test_include_bound_as_inequality()
-    m = jmp.Model()
-    @jmp.variable(m, 0 <= x[1:2])
-    @jmp.constraint(m, eq1, x[1] + 2*x[2] == 1)
+    m = JuMP.Model()
+    @JuMP.variable(m, 0 <= x[1:2])
+    @JuMP.constraint(m, eq1, x[1] + 2*x[2] == 1)
     graph, con_node_map, var_node_map = get_bipartite_incidence_graph(
         m, include_inequality = true
     )
@@ -104,16 +101,16 @@ function test_include_bound_as_inequality()
     @test length(A) == 3
     @test length(B) == 2
     @test length(E) == 4
-    pred_con_set = Set([eq1, jmp.LowerBoundRef(x[1]), jmp.LowerBoundRef(x[2])])
+    pred_con_set = Set([eq1, JuMP.LowerBoundRef(x[1]), JuMP.LowerBoundRef(x[2])])
     @test pred_con_set == keys(con_node_map)
     return
 end
 
 function test_construct_from_constraints()
-    m = jmp.Model()
-    @jmp.variable(m, x[1:3])
-    @jmp.constraint(m, eq1, x[1] + 2*x[2] == 1)
-    @jmp.constraint(m, eq2, x[2]*x[3] == 0.5)
+    m = JuMP.Model()
+    @JuMP.variable(m, x[1:3])
+    @JuMP.constraint(m, eq1, x[1] + 2*x[2] == 1)
+    @JuMP.constraint(m, eq2, x[2]*x[3] == 0.5)
     cons = [eq1, eq2]
     graph, con_node_map, var_node_map = get_bipartite_incidence_graph(cons)
     A, B, E = graph
@@ -131,10 +128,10 @@ function test_construct_from_constraints()
 end
 
 function test_construct_from_constraints_and_variables()
-    m = jmp.Model()
-    @jmp.variable(m, x[1:3])
-    @jmp.constraint(m, eq1, x[1] + 2*x[2] == 1)
-    @jmp.constraint(m, eq2, x[2]*x[3] == 0.5)
+    m = JuMP.Model()
+    @JuMP.variable(m, x[1:3])
+    @JuMP.constraint(m, eq1, x[1] + 2*x[2] == 1)
+    @JuMP.constraint(m, eq2, x[2]*x[3] == 0.5)
     cons = [eq2, eq1]
     vars = [x[3], x[2], x[1]]
     graph, con_node_map, var_node_map = get_bipartite_incidence_graph(cons, vars)
@@ -155,17 +152,10 @@ function test_construct_from_constraints_and_variables()
     return
 end
 
-function runtests()
+@testset "incidence-graph" begin
     test_get_incidence_graph()
     test_get_incidence_graph_badconstraint()
     test_include_bound_as_inequality()
     test_construct_from_constraints()
     test_construct_from_constraints_and_variables()
-    return
-end
-
-end # module TestIncidenceGraph
-
-if abspath(PROGRAM_FILE) == @__FILE__
-    TestIncidenceGraph.runtests()
 end

--- a/test/incidence_matrix.jl
+++ b/test/incidence_matrix.jl
@@ -17,24 +17,19 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-module TestIncidenceMatrix
-
-import JuMP as jmp
-import MathOptInterface as moi
+import JuMP
 import SparseArrays
-using Test: @test, @test_throws
+using Test: @test, @test_throws, @testset
 
 import JuMPIn as ji
 
-include("models.jl") # Models
-using .Models: make_degenerate_flow_model
-
+include("models.jl") # make_degenerate_flow_model
 
 function test_incidence_matrix_from_constraints_and_variables()
-    m = jmp.Model()
-    @jmp.variable(m, x[1:3])
-    @jmp.constraint(m, eq1, 2*x[1] + 3*x[2] == 4)
-    @jmp.NLconstraint(m, eq2, 2*x[3]^1.5*x[2] == 1)
+    m = JuMP.Model()
+    @JuMP.variable(m, x[1:3])
+    @JuMP.constraint(m, eq1, 2*x[1] + 3*x[2] == 4)
+    @JuMP.NLconstraint(m, eq2, 2*x[3]^1.5*x[2] == 1)
     constraints = [eq1, eq2]
     variables = [x[1], x[2], x[3]]
     imat = ji.incidence_matrix(constraints, variables)
@@ -48,10 +43,10 @@ function test_incidence_matrix_from_constraints_and_variables()
 end
 
 function test_incidence_matrix_from_incidence_graph()
-    m = jmp.Model()
-    @jmp.variable(m, x[1:3])
-    @jmp.constraint(m, eq1, 2*x[1] + 3*x[2] == 4)
-    @jmp.NLconstraint(m, eq2, 2*x[3]^1.5*x[2] == 1)
+    m = JuMP.Model()
+    @JuMP.variable(m, x[1:3])
+    @JuMP.constraint(m, eq1, 2*x[1] + 3*x[2] == 4)
+    @JuMP.NLconstraint(m, eq2, 2*x[3]^1.5*x[2] == 1)
     constraints = [eq1, eq2]
     variables = [x[3], x[2], x[1]]
     igraph = ji.IncidenceGraphInterface(constraints, variables)
@@ -65,15 +60,7 @@ function test_incidence_matrix_from_incidence_graph()
     @test imat == pred_mat
 end
 
-
-function runtests()
+@testset "incidence-matrix" begin
     test_incidence_matrix_from_constraints_and_variables()
     test_incidence_matrix_from_incidence_graph()
-    return
-end
-
-end # module TestIncidenceGraph
-
-if abspath(PROGRAM_FILE) == @__FILE__
-    TestIncidenceMatrix.runtests()
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -17,20 +17,11 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-module TestInterface
-
-using Test: @test, @test_throws
+using Test: @test, @test_throws, @testset
 import JuMP
 import JuMPIn as ji
 
-# Note: Do not import from IncidenceGraphInterface here; this will
-# lead to the module being defined multiple times, and causes problems
-# in the REPL.
-#using .Interface: IncidenceGraphInterface
-
-include("models.jl")
-using .Models: make_degenerate_flow_model
-
+include("models.jl") # make_degenerate_flow_model
 
 function _test_igraph_fields(igraph, constraints, variables)
     @test Set(variables) == keys(igraph._var_node_map)
@@ -298,7 +289,7 @@ function test_dulmage_mendelsohn_from_constraints_and_variables()
     return
 end
 
-function runtests()
+@testset "interface" begin
     test_construct_interface()
     test_construct_interface_rectangular()
     test_get_adjacent_to_linear_constraint()
@@ -312,11 +303,4 @@ function runtests()
     test_interface_from_constraints_and_variables()
     test_matching_from_constraints_and_variables()
     test_dulmage_mendelsohn_from_constraints_and_variables()
-end
-
-end
-
-
-if abspath(PROGRAM_FILE) == @__FILE__
-    TestInterface.runtests()
 end

--- a/test/models.jl
+++ b/test/models.jl
@@ -17,38 +17,23 @@
 #  This software is distributed under the 3-clause BSD license.
 #  ___________________________________________________________________________
 
-module Models
-export make_degenerate_flow_model
-import JuMP as jmp
+import JuMP
 
 function make_degenerate_flow_model()
-    m = jmp.Model()
+    m = JuMP.Model()
     comps = [1, 2, 3]
-    @jmp.variable(m, x[comps], start=1/3.0)
-    @jmp.variable(m, flow_comp[comps], start=10.0)
-    @jmp.variable(m, flow, start=30.0)
-    @jmp.variable(m, rho, start=1.0)
+    @JuMP.variable(m, x[comps], start=1/3.0)
+    @JuMP.variable(m, flow_comp[comps], start=10.0)
+    @JuMP.variable(m, flow, start=30.0)
+    @JuMP.variable(m, rho, start=1.0)
 
     # sum_component_eqn
-    @jmp.constraint(m, sum_comp_eqn, sum(x) == 1)
+    @JuMP.constraint(m, sum_comp_eqn, sum(x) == 1)
     # component_density_eqn
-    @jmp.constraint(m, comp_dens_eqn, x*rho .== [1.0, 1.1, 1.2])
+    @JuMP.constraint(m, comp_dens_eqn, x*rho .== [1.0, 1.1, 1.2])
     # density_eqn
-    @jmp.NLconstraint(m, bulk_dens_eqn, 1/rho - sum(1/x[j] for j in comps) == 0)
+    @JuMP.NLconstraint(m, bulk_dens_eqn, 1/rho - sum(1/x[j] for j in comps) == 0)
     # component_flow_eqn
-    @jmp.constraint(m, comp_flow_eqn, x.*flow .== flow_comp)
+    @JuMP.constraint(m, comp_flow_eqn, x.*flow .== flow_comp)
     return m
-end
-
-function main()
-    # The purpose of this function is so that, to "test" this module's
-    # functionality from the REPL, I only have to remember to call the
-    # function main, rather than any of the specific functions.
-    println(models.make_degenerate_flow_model())
-end
-
-end # module models
-
-if abspath(PROGRAM_FILE) == @__FILE__
-    Models.main()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,30 +21,9 @@ using JuMPIn
 using Test
 
 @testset "JuMPIn.jl" begin
-
-    @testset "IdentifyVariables" begin
-        include("identify_variables.jl")
-        TestIdentifyVariables.runtests()
-    end
-
-    @testset "GetEquality" begin
-        include("get_equality.jl")
-        TestGetEquality.runtests()
-    end
-
-    @testset "IncidenceGraph" begin
-        include("incidence_graph.jl")
-        TestIncidenceGraph.runtests()
-    end
-
-    @testset "Interface" begin
-        include("interface.jl")
-        TestInterface.runtests()
-    end
-
-    @testset "IncidenceMatrix" begin
-        include("incidence_matrix.jl")
-        TestIncidenceMatrix.runtests()
-    end
-
+    include("identify_variables.jl")
+    include("get_equality.jl")
+    include("incidence_graph.jl")
+    include("interface.jl")
+    include("incidence_matrix.jl")
 end


### PR DESCRIPTION
Previously I used some imports like `import Graphs as gjl` and `import JuMP as jmp`. I have updated to use the more conventional `import Graphs` and `import JuMP`.