### PR TITLE
Add `connected_components` function

### DIFF
--- a/docs/src/reference/interface.md
+++ b/docs/src/reference/interface.md
@@ -9,4 +9,5 @@ IncidenceGraphInterface
 get_adjacent
 maximum_matching
 dulmage_mendelsohn
+connected_components
 ```

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -360,6 +360,34 @@ the variables in each connected component and the constraints in each
 connected component. Note that the input graph is undirected, so there is no
 distinction between strongly and weakly connected components.
 
+# Example
+```julia-repl
+julia> using JuMP
+
+julia> import JuMPIn as ji
+
+julia> m = Model();
+
+julia> @variable(m, x[1:2] >= 0);
+
+julia> @constraint(m, eq1, x[1] == 1);
+
+julia> @constraint(m, eq2, x[2]^2 == 2);
+
+julia> igraph = ji.IncidenceGraphInterface(m);
+
+julia> con_comps, var_comps = ji.connected_components(igraph);
+
+julia> con_comps
+2-element Vector{Vector{ConstraintRef}}:
+ [eq1 : x[1] = 1]
+ [eq2 : x[2]² = 2]
+
+julia> var_comps
+2-element Vector{Vector{VariableRef}}:
+ [x[1]]
+ [x[2]]
+```
 """
 function connected_components(
     igraph::IncidenceGraphInterface

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -353,7 +353,7 @@ end
     connected_components(igraph::IncidenceGraphInterface)
 
 Return the connected components of a bipartite incidence graph of constraints
-and components.
+and variables.
 
 The connected components are returned as two vector-of-vectors, containing
 the variables in each connected component and the constraints in each
@@ -387,6 +387,7 @@ julia> var_comps
 2-element Vector{Vector{VariableRef}}:
  [x[1]]
  [x[2]]
+
 ```
 """
 function connected_components(
@@ -401,6 +402,52 @@ function connected_components(
     return con_comps, var_comps
 end
 
+"""
+    connected_components(constraints, variables)
+
+Return the connected components of a bipartite incidence graph of constraints
+and variables.
+
+The method that accepts constraints and variables directly is convenient for
+working with the output of the Dulmage-Mendelsohn partition. It is often used
+to decompose and help debug the over and under-constrained subsystems.
+
+# Example
+```julia-repl
+julia> using JuMP
+
+julia> import JuMPIn as ji
+
+julia> m = Model();
+
+julia> @variable(m, x[1:4] >= 0);
+
+julia> @constraint(m, eq1, x[1] + x[3] == 7);
+
+julia> @constraint(m, eq2, x[2]^2 + x[4]^2 == 1);
+
+julia> igraph = ji.IncidenceGraphInterface(m);
+
+julia> con_dmp, var_dmp = ji.dulmage_mendelsohn(igraph);
+
+julia> uc_con = con_dmp.underconstrained;
+
+julia> uc_var = [var_dmp.unmatched..., var_dmp.underconstrained...];
+
+julia> con_comps, var_comps = ji.connected_components(uc_con, uc_var);
+
+julia> con_comps
+2-element Vector{Vector{ConstraintRef}}:
+ [eq1 : x[1] + x[3] = 7]
+ [eq2 : x[2]² + x[4]² = 1]
+
+julia> var_comps
+2-element Vector{Vector{VariableRef}}:
+ [x[3], x[1]]
+ [x[4], x[2]]
+
+```
+"""
 function connected_components(
     constraints::Vector{<:JuMP.ConstraintRef},
     variables::Vector{JuMP.VariableRef},

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -348,3 +348,35 @@ function dulmage_mendelsohn(
     igraph = IncidenceGraphInterface(constraints, variables)
     return dulmage_mendelsohn(igraph)
 end
+
+"""
+    connected_components(igraph::IncidenceGraphInterface)
+
+Return the connected components of a bipartite incidence graph of constraints
+and components.
+
+The connected components are returned as two vector-of-vectors, containing
+the variables in each connected component and the constraints in each
+connected component. Note that the input graph is undirected, so there is no
+distinction between strongly and weakly connected components.
+
+"""
+function connected_components(
+    igraph::IncidenceGraphInterface
+)::Tuple{Vector{Vector{JuMP.ConstraintRef}}, Vector{Vector{JuMP.VariableRef}}}
+    comps = Graphs.connected_components(igraph._graph)
+    ncon = length(igraph._con_node_map)
+    nodes = igraph._nodes
+    con_node_set = Set(1:ncon)
+    con_comps = [[nodes[n] for n in comp if n in con_node_set] for comp in comps]
+    var_comps = [[nodes[n] for n in comp if !(n in con_node_set)] for comp in comps]
+    return con_comps, var_comps
+end
+
+function connected_components(
+    constraints::Vector{<:JuMP.ConstraintRef},
+    variables::Vector{JuMP.VariableRef},
+)::Tuple{Vector{Vector{JuMP.ConstraintRef}}, Vector{Vector{JuMP.VariableRef}}}
+    igraph = IncidenceGraphInterface(constraints, variables)
+    return connected_components(igraph)
+end


### PR DESCRIPTION
Fixes #16.

Adds `connected_components(IncidenceGraphInterface)` and `connected_components(constraints, variables)`, which are thin wrappers around the Graphs.jl `connected_components` function.