### PR TITLE
Minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ julia> ]
 This package depends on
 [JuMP](https://github.com/jump-dev/jump.jl),
 [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl),
-[BipartiteMatching.jl](https://github.com/IsaacRudich/BipartiteMatching.jl),
 and the dependencies thereof.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ git clone https://github.com/lanl-ansi/JuMPIn.jl
 $ cd JuMPIn.jl
 $ julia
 julia> ]
-(v1.8) pkg> add .
+(v1.9) pkg> add .
 ```
 
 ## Dependencies
@@ -47,10 +47,10 @@ comps = [1, 2, 3]
 
 igraph = ji.IncidenceGraphInterface(m)
 con_dmp, var_dmp = ji.dulmage_mendelsohn(igraph)
-oc_con = cat(con_dmp.overconstrained, con_dmp.unmatched, dims = 1)
+oc_con = [con_dmp.overconstrained..., con_dmp.unmatched...]
 oc_var = var_dmp.overconstrained
 uc_con = con_dmp.underconstrained
-uc_var = cat(var_dmp.unmatched, var_dmp.underconstrained, dims = 1)
+uc_var = [var_dmp.unmatched..., var_dmp.underconstrained...]
 
 println("Overconstrained subsystem")
 println("-------------------------")

--- a/src/get_equality.jl
+++ b/src/get_equality.jl
@@ -140,14 +140,21 @@ Return a vector of equality constraints in the provided model.
 # Example
 ```julia-repl
 julia> using JuMP
+
 julia> import JuMPIn as ji
+
 julia> m = Model();
+
 julia> @variable(m, v);
+
 julia> @constraint(m, v == 1);
+
 julia> eq_cons = ji.get_equality_constraints(m);
+
 julia> display(eq_cons)
 1-element Vector{ConstraintRef}:
  eq_con_1 : v = 1.0
+
 ```
 
 """

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -47,16 +47,24 @@ to work...
 # Example
 ```julia-repl
 julia> using JuMP
+
 julia> import JuMPIn as ji
+
 julia> m = Model();
+
 julia> @variable(m, v[1:3]);
+
 julia> @constraint(m, eq_1, v[2] == 1);
+
 julia> @NLconstraint(m, eq_2, v[2]*v[3]^1.5 == 2);
+
 julia> vars = ji.identify_unique_variables([eq_1, eq_2]);
+
 julia> display(vars)
 2-element Vector{VariableRef}:
  v[2]
  v[3]
+
 ```
 
 """

--- a/src/incidence_graph.jl
+++ b/src/incidence_graph.jl
@@ -59,23 +59,36 @@ the model, and the variables are those that participate in these constraints.
 # Example
 ```julia-repl
 julia> using JuMP
+
 julia> import JuMPIn as ji
+
 julia> m = Model();
+
 julia> @variable(m, v[1:3]);
+
 julia> @constraint(m, eq_1, v[1] + v[3]^2 == 1.0);
+
 julia> @NLconstraint(m, eq_2, v[1]*v[2]^1.5 == 2.0);
+
 julia> graph, con_node_map, var_node_map = ji.get_bipartite_incidence_graph(m);
+
 julia> A, B, E = graph;
+
 julia> M = length(A);
+
 julia> N = length(B);
+
 julia> imat = zeros(M, N);
+
 julia> for (a, b) in E
-julia>     imat[a, b-M] = 1.0;
-julia> end
+           imat[a, b-M] = 1.0;
+       end
+
 julia> display(imat)
 2×3 Matrix{Float64}:
  1.0  1.0  0.0
  0.0  1.0  1.0
+
 ```
 
 # Convention

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -148,17 +148,26 @@ Return the constraints adjacent to a variable in an incidence graph.
 # Example
 ```julia-repl
 julia> using JuMP
+
 julia> import JuMPIn as ji
+
 julia> m = Model();
+
 julia> @variable(m, v[1:3]);
+
 julia> @constraint(m, eq_1, v[1] + v[3] == 1);
+
 julia> @NLconstraint(m, eq_2, v[1]*v[2]^3 == 2);
+
 julia> igraph = ji.IncidenceGraphInterface(m);
+
 julia> adj_cons = ji.get_adjacent(igraph, v[1]);
+
 julia> display(adj_cons)
 2-element Vector{ConstraintRef}:
  eq_1 : v[1] + v[3] = 1.0
  v[1] * v[2] ^ 3.0 - 2.0 = 0
+
 ```
 
 """
@@ -182,17 +191,26 @@ The returned `Dict` maps JuMP `ConstraintRef`s to their matched `VariableRef`s.
 # Example
 ```julia-repl
 julia> using JuMP
+
 julia> import JuMPIn as ji
+
 julia> m = Model();
+
 julia> @variable(m, v[1:3]);
+
 julia> @constraint(m, eq_1, v[1] + v[3] == 1);
+
 julia> @NLconstraint(m, eq_2, v[1]*v[2]^3 == 2);
+
 julia> igraph = ji.IncidenceGraphInterface(m);
+
 julia> matching = ji.maximum_matching(igraph);
+
 julia> display(matching)
 Dict{ConstraintRef, VariableRef} with 2 entries:
   v[1] * v[2] ^ 3.0 - 2.0 = 0 => v[2]
   eq_1 : v[1] + v[3] = 1.0 => v[1]
+
 ```
 
 """
@@ -285,35 +303,50 @@ and constraints.
 # Example
 ```julia-repl
 julia> using JuMP
+
 julia> import JuMPIn as ji
+
 julia> m = Model();
+
 julia> @variable(m, v[1:4]);
+
 julia> @constraint(m, eq_1, v[1] + v[3] == 1);
+
 julia> @NLconstraint(m, eq_2, v[1]*v[2]^3 == 2);
+
 julia> @constraint(m, eq_3, v[4]^2 == 3);
+
 julia> igraph = ji.IncidenceGraphInterface(m);
+
 julia> con_dmp, var_dmp = ji.dulmage_mendelsohn(igraph);
+
 julia> # Assert that there are no unmatched constraints
+
 julia> @assert isempty(con_dmp.unmatched);
+
 julia> display(var_dmp.unmatched)
 1-element Vector{VariableRef}:
  v[3]
+
 julia> display(var_dmp.underconstrained)
 2-element Vector{VariableRef}:
  v[1]
  v[2]
+
 julia> display(con_dmp.underconstrained)
 2-element Vector{ConstraintRef}:
  eq_1 : v[1] + v[3] = 1.0
  v[1] * v[2] ^ 3.0 - 2.0 = 0
+ 
 julia> display(var_dmp.square)
 1-element Vector{VariableRef}:
  v[4]
+
 julia> display(con_dmp.square)
 1-element Vector{ConstraintRef}:
  eq_3 : v[4]² = 3.0
-julia> # As there are no unmatched constraints, the overconstrained subsystem
-julia> # is empty.
+
+julia> # As there are no unmatched constraints, the overconstrained subsystem is empty
 ```
 
 """


### PR DESCRIPTION
- Remove BipartiteMatching.jl from README's list of dependencies
- Update examples in API docs to add a space between lines of the Julia REPL (as these lines appear in the actual REPL)
- Update example in README to use splatting instead of `cat`